### PR TITLE
Update Tastypie spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # manager-for-lustre-dependencies
 
-[![Build Status](https://travis-ci.org/intel-hpdd/manager-for-lustre-dependencies.svg?branch=master)](https://travis-ci.org/intel-hpdd/manager-for-lustre-dependencies)
+[![Build Status](https://travis-ci.org/whamcloud/manager-for-lustre-dependencies.svg?branch=master)](https://travis-ci.org/whamcloud/manager-for-lustre-dependencies)
 
 Dependencies needed for IML not available elsewhere.
 
 ## Overview
 
-This repo is organized such that each directory cooresponds to a dependency. 
+This repo is organized such that each directory cooresponds to a dependency.
 
 The dependencies are reflected in our [copr project](https://copr.fedorainfracloud.org/coprs/managerforlustre/manager-for-lustre/).
 
@@ -23,4 +23,3 @@ In the directory you want to update:
 3. Upload your change as a PR and pass review.
 4. Tag your change using [tito](https://github.com/dgoodwin/tito): `tito tag --no-auto-changelog --keep-version`
 5. Push your change, a gatekeeper will land, and a build will be kicked off.
-

--- a/django-tastypie/django-tastypie.spec
+++ b/django-tastypie/django-tastypie.spec
@@ -4,7 +4,7 @@
 
 Name:           django-tastypie
 Version:        0.9.16
-Release:        0.01%{?dist}
+Release:        0.02%{?dist}
 Summary:        Tastypie is an webservice API framework for Django
 
 Group:          Development/Languages
@@ -21,6 +21,7 @@ Requires:       python-mimeparse >= 0.1.3
 Requires:       python-dateutil >= 1.5
 Requires:       python-dateutil < 2.0
 Requires:       Django >= 1.2.0
+Provides:       python2-django-tastypie
 
 BuildArch:      noarch
 BuildRequires:  python2-devel
@@ -83,6 +84,9 @@ cp -p LICENSE README.rst AUTHORS -t %{buildroot}%{docdir}
 %exclude %{docdir}/html/.buildinfo
 
 %changelog
+* Fri Jan 25 2018 Joe Grund <jgrund@whamcloud.com> 0.9.16-0.02
+- Bump release to account for new provides
+
 * Tue Jun 27 2017 Joe Grund <joe.grund@intel.com> 0.9.16-0.01
 - Bump version to 0.9.16 (joe.grund@intel.com)
 

--- a/django-tastypie/django-tastypie.spec
+++ b/django-tastypie/django-tastypie.spec
@@ -84,7 +84,7 @@ cp -p LICENSE README.rst AUTHORS -t %{buildroot}%{docdir}
 %exclude %{docdir}/html/.buildinfo
 
 %changelog
-* Fri Jan 25 2018 Joe Grund <jgrund@whamcloud.com> 0.9.16-0.02
+* Fri Jan 25 2019 Joe Grund <jgrund@whamcloud.com> 0.9.16-0.02
 - Bump release to account for new provides
 
 * Tue Jun 27 2017 Joe Grund <joe.grund@intel.com> 0.9.16-0.01

--- a/test_inside_docker.sh
+++ b/test_inside_docker.sh
@@ -16,9 +16,10 @@ baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager
 enabled=1
 
 [lustre-client]
-name=added from: https://build.hpdd.intel.com/job/lustre-master/lastSuccessfulBuild/arch=x86_64,build_type=client,distro=el7,ib_stack=inkernel/artifact/artifacts/
-baseurl=https://build.hpdd.intel.com/job/lustre-master/lastSuccessfulBuild/arch=x86_64%2Cbuild_type=client%2Cdistro=el7%2Cib_stack=inkernel/artifact/artifacts/
+name=Lustre Client
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.10.6/el7/client/
 enabled=1
+gpgcheck=0
 .
 w
 q


### PR DESCRIPTION
Update the tastypie spec to provide `python2-django-tastypie`.

This way, django-tastypie will be uninstalled when we upgrade to
iml-4.0.9

Signed-off-by: Joe Grund <jgrund@whamcloud.io>